### PR TITLE
Add pointer-tracker as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "homepage": "https://github.com/GoogleChromeLabs/two-up#readme",
   "devDependencies": {
-    "pointer-tracker": "^2.0.3",
     "rollup": "^0.66.6",
     "rollup-plugin-node-resolve": "^3.4.0",
     "rollup-plugin-postcss": "^1.6.2",
@@ -35,5 +34,7 @@
     "typed-css-modules": "^0.3.7",
     "typescript": "^3.1.4"
   },
-  "dependencies": {}
+  "dependencies": {
+    "pointer-tracker": "^2.0.3"
+  }
 }


### PR DESCRIPTION
`pointer-tracker` is referenced by `dist/two-up.mjs`, but since it was a `devDependency` it never gets installed.