### PR TITLE
Avoid forced layout during dragging

### DIFF
--- a/lib/two-up.ts
+++ b/lib/two-up.ts
@@ -43,8 +43,11 @@ export default class TwoUp extends HTMLElement {
 
     // Watch for element size changes.
     if ('ResizeObserver' in window) {
-      new ResizeObserver(() => this._resetPosition())
-        .observe(this);
+      new ResizeObserver(() => {
+        // Ignore child resize events during handle dragging
+        if (pointerTracker.currentPointers.length > 0) return;
+        this._resetPosition();
+      }).observe(this);
     } else {
       window.addEventListener('resize', () => this._resetPosition());
     }


### PR DESCRIPTION
This fixes a performance issue when `<two-up>` is used as a split view, where dragging triggers ResizeObserver which causes `_resetPosition()` to be invoked that in turn called `getBoundingClientRect()`.

Here's the CSS I'm using to turn `<two-up>` into a split view:

```css
body two-up {
	display: flex !important;
	grid: none !important;

	> * {
		grid-area: none !important;
	}

	> :first-child {
		box-sizing: border-box;
		clip-path: none !important;
		order: 1;
	}

	> :nth-child(2) {
		box-sizing: border-box;
		clip-path: none !important;
		order: 3;
	}

	> :last-child {
		position: absolute;
		order: 2;
		z-index: 2;
	}

	&:not([orientation="vertical"]) {
		> *:first-child {
			width: var(--split-point, 50%);
			min-width: var(--split-point, 50%);
			max-width: var(--split-point, 50%);
		}
		> *:last-child {
			height: 100%;
		}
	}

	&[orientation="vertical"] {
		flex-direction: column;
		> *:first-child {
			box-sizing: border-box;
			clip-path: none !important;
			height: var(--split-point, 50%);
			min-height: var(--split-point, 50%);
			max-height: var(--split-point, 50%);
			order: 1;
		}
		> *:last-child {
			width: 100%;
		}
	}
}
```